### PR TITLE
Read post processing treats 300 codes as failures

### DIFF
--- a/packages/core/src/read/__tests__/http.js
+++ b/packages/core/src/read/__tests__/http.js
@@ -24,9 +24,9 @@ describe('http', () => {
       expect(http.isOK({ meta: {} })).not.toBeTruthy()
     })
 
-    test('is ok if it has a status of 2xx **and** it has a value', () => {
+    test('is ok if it has a status of 2xx or 3xx **and** it has a value', () => {
       expect(http.isOK({ value: 1, meta: { status: 222 } })).toBeTruthy()
-      expect(http.isOK({ value: 1, meta: { status: 300 } })).not.toBeTruthy()
+      expect(http.isOK({ value: 1, meta: { status: 300 } })).toBeTruthy()
       expect(http.isOK({ value: 1, meta: { status: 200 } })).toBeTruthy()
       expect(http.isOK({ meta: { status: 200 } })).not.toBeTruthy()
     })

--- a/packages/core/src/read/http.js
+++ b/packages/core/src/read/http.js
@@ -143,6 +143,6 @@ export function isOK(response) {
 
   return (
     (response.value != null && status == null) ||
-    (response.value != null && status >= 200 && status < 300)
+    (response.value != null && status >= 200 && status < 400)
   )
 }


### PR DESCRIPTION
Treat redirect response codes as successful in default http read response processing