### PR TITLE
Add viewport enter and leave callbacks

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -42,7 +42,7 @@ const ViewportAwareImage = Viewport.Aware(Image);
 render() {
   return (
     <ViewportAwareImage
-      source={{uri: 'https://facebook.github.io/react-native/img/header_logo.png'}}
+      source={{ uri: 'https://facebook.github.io/react-native/img/header_logo.png' }}
       preTriggerRatio={0.5}
       onViewportEnter={() => console.log('Entered!')}
       onViewportLeave={() => console.log('Left!')} />
@@ -79,7 +79,7 @@ render() {
   return (
     <ViewportAwareImageWithPlaceholder
       // placeholder={Placeholder} // passing down a placeholder at render time
-      source={{uri: 'https://facebook.github.io/react-native/img/header_logo.png'}}
+      source={{ uri: 'https://facebook.github.io/react-native/img/header_logo.png' }}
       preTriggerRatio={0.5}
       style={{ width: 50, height: 50 }} />
   );

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -42,7 +42,7 @@ const ViewportAwareImage = Viewport.Aware(Image);
 render() {
   return (
     <ViewportAwareImage
-      source={{uri: 'https://facebook.github.io/react/img/logo_og.png'}}
+      source={{uri: 'https://facebook.github.io/react-native/img/header_logo.png'}}
       preTriggerRatio={0.5}
       onViewportEnter={() => console.log('Entered!')}
       onViewportLeave={() => console.log('Left!')} />
@@ -79,7 +79,7 @@ render() {
   return (
     <ViewportAwareImageWithPlaceholder
       // placeholder={Placeholder} // passing down a placeholder at render time
-      source={{uri: 'https://facebook.github.io/react/img/logo_og.png'}}
+      source={{uri: 'https://facebook.github.io/react-native/img/header_logo.png'}}
       preTriggerRatio={0.5}
       style={{ width: 50, height: 50 }} />
   );

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -6,7 +6,8 @@ Skele's `components` package is a library of custom components that aid in build
 
 ### Viewport Tracker
 
-Tracks the position and size of a `ScrollView` or `ListView` viewport. Communicates it to all viewport aware child components.
+Tracks the position and size of a `ScrollView`, `FlatList` or `SectionList` viewport.
+Communicates it to all viewport aware child components.
 
 #### Usage
 
@@ -16,7 +17,7 @@ import { Viewport } from '@skele/components';
 render() {
   return (
     <Viewport.Tracker>
-      <ScrollView>
+      <ScrollView scrollEventThrottle={16}>
         { this.props.children }
       </ScrollView>
     </Viewport.Tracker>
@@ -26,7 +27,10 @@ render() {
 
 ### Viewport Aware
 
-A higher-order component that processes the information communicated by the viewport tracker. Determines whether the wrapped component is in or outside the viewport. Updates the `inViewport` parameter of the wrapped component accordingly.
+A higher-order component that processes the information communicated by the viewport tracker.
+Determines whether the wrapped component is in or outside the viewport.
+Updates the `inViewport` parameter of the wrapped component accordingly.
+Invokes `onViewportEnter` and `onViewportLeave` when the component enters or leaves the viewport.
 
 #### Usage
 
@@ -39,7 +43,9 @@ render() {
   return (
     <ViewportAwareImage
       source={{uri: 'https://facebook.github.io/react/img/logo_og.png'}}
-      preTriggerRatio={0.5} />
+      preTriggerRatio={0.5}
+      onViewportEnter={() => console.log('Entered!')}
+      onViewportLeave={() => console.log('Left!')} />
   );
 }
 ```
@@ -48,11 +54,25 @@ render() {
 
 | Prop | Description | Default |
 |---|---|---|
-|**`preTriggerRatio`**| Determines pre-triggering of `inViewport`. Useful for rendering components beforehand to improve user experience. A ratio of `0.5` means that the effective viewport will be twice the size of the real viewport. | `0` |
+
+|**`preTriggerRatio`**|
+Determines pre-triggering of `inViewport`.
+Useful for rendering components beforehand to improve user experience.
+A ratio of `0.5` means that the effective viewport will be twice the size of the real viewport.
+| `0` |
+
+|**`onViewportEnter`**|
+Invoked when the component enters the viewport.
+| `null` |
+
+|**`onViewportLeave`**|
+Invoked when the component leaves the viewport.
+| `null` |
 
 ### With Place Holder
 
-A higher-order component that can be used to display a place holder while the component is not in the viewport. This can improve user experience.
+A higher-order component that can be used to display a place holder while the component is not in the viewport.
+This can improve user experience since it can serve as a mechanism for lazy loading.
 
 #### Usage
 
@@ -60,13 +80,16 @@ A higher-order component that can be used to display a place holder while the co
 import { Image, View } from 'react-native';
 import { Viewport } from '@skele/components';
 
-const PlaceHolder = () => <View style={{ width: 50, height: 50, backgroundColor: 'darkgrey' }} />
+const PlaceHolder = () =>
+  <View style={{ width: 50, height: 50, backgroundColor: 'darkgrey' }} />
 
-const ViewportAwareImageWithPlaceholder = Viewport.Aware(Viewport.WithPlaceHolder(Image, PlaceHolder));
+const ViewportAwareImageWithPlaceholder =
+  Viewport.Aware(Viewport.WithPlaceHolder(Image, PlaceHolder));
 
 render() {
   return (
     <ViewportAwareImageWithPlaceholder
+      // placeHolder={Placeholder} // passing down a place holder at render time
       source={{uri: 'https://facebook.github.io/react/img/logo_og.png'}}
       preTriggerRatio={0.5}
       style={{ width: 50, height: 50 }} />

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -54,24 +54,13 @@ render() {
 
 | Prop | Description | Default |
 |---|---|---|
+|**`preTriggerRatio`**| Determines pre-triggering of `inViewport`. Useful for rendering components beforehand to improve user experience. A ratio of `0.5` means that the effective viewport will be twice the size of the real viewport. | `0` |
+|**`onViewportEnter`**| Invoked when the component enters the viewport. | `null` |
+|**`onViewportLeave`**| Invoked when the component leaves the viewport. | `null` |
 
-|**`preTriggerRatio`**|
-Determines pre-triggering of `inViewport`.
-Useful for rendering components beforehand to improve user experience.
-A ratio of `0.5` means that the effective viewport will be twice the size of the real viewport.
-| `0` |
+### With Placeholder
 
-|**`onViewportEnter`**|
-Invoked when the component enters the viewport.
-| `null` |
-
-|**`onViewportLeave`**|
-Invoked when the component leaves the viewport.
-| `null` |
-
-### With Place Holder
-
-A higher-order component that can be used to display a place holder while the component is not in the viewport.
+A higher-order component that can be used to display a placeholder while the component is not in the viewport.
 This can improve user experience since it can serve as a mechanism for lazy loading.
 
 #### Usage
@@ -80,16 +69,16 @@ This can improve user experience since it can serve as a mechanism for lazy load
 import { Image, View } from 'react-native';
 import { Viewport } from '@skele/components';
 
-const PlaceHolder = () =>
+const Placeholder = () =>
   <View style={{ width: 50, height: 50, backgroundColor: 'darkgrey' }} />
 
 const ViewportAwareImageWithPlaceholder =
-  Viewport.Aware(Viewport.WithPlaceHolder(Image, PlaceHolder));
+  Viewport.Aware(Viewport.WithPlaceholder(Image, Placeholder));
 
 render() {
   return (
     <ViewportAwareImageWithPlaceholder
-      // placeHolder={Placeholder} // passing down a place holder at render time
+      // placeholder={Placeholder} // passing down a placeholder at render time
       source={{uri: 'https://facebook.github.io/react/img/logo_og.png'}}
       preTriggerRatio={0.5}
       style={{ width: 50, height: 50 }} />
@@ -101,4 +90,4 @@ render() {
 
 | Prop | Description | Default |
 |---|---|---|
-|**`placeHolder`**| Useful for passing down a place holder at render time. | `null` |
+|**`placeholder`**| Useful for passing down a placeholder at render time. | `null` |

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -31,7 +31,7 @@ A higher-order component that processes the information communicated by the view
 Determines whether the wrapped component is in or outside the viewport.
 Updates the `inViewport` property of the wrapped component accordingly.
 Invokes `onViewportEnter` and `onViewportLeave` when the component enters or leaves the viewport.
-Note that handling updates of `inViewport` is the preferred way for reacting to visibility changes.
+Note that handling updates of `inViewport` is the preferred way of reacting to visibility changes.
 
 #### Usage
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -12,7 +12,7 @@ Communicates it to all viewport aware child components.
 #### Usage
 
 ```javascript
-import { Viewport } from '@skele/components';
+import { Viewport } from '@skele/components'
 
 render() {
   return (
@@ -21,7 +21,7 @@ render() {
         { this.props.children }
       </ScrollView>
     </Viewport.Tracker>
-  );
+  )
 }
 ```
 
@@ -29,15 +29,16 @@ render() {
 
 A higher-order component that processes the information communicated by the viewport tracker.
 Determines whether the wrapped component is in or outside the viewport.
-Updates the `inViewport` parameter of the wrapped component accordingly.
+Updates the `inViewport` property of the wrapped component accordingly.
 Invokes `onViewportEnter` and `onViewportLeave` when the component enters or leaves the viewport.
+Note that handling updates of `inViewport` is the preferred way for reacting to visibility changes.
 
 #### Usage
 
 ```javascript
-import { Image } from 'react-native';
-import { Viewport } from '@skele/components';
-const ViewportAwareImage = Viewport.Aware(Image);
+import { Image } from 'react-native'
+import { Viewport } from '@skele/components'
+const ViewportAwareImage = Viewport.Aware(Image)
 
 render() {
   return (
@@ -46,7 +47,7 @@ render() {
       preTriggerRatio={0.5}
       onViewportEnter={() => console.log('Entered!')}
       onViewportLeave={() => console.log('Left!')} />
-  );
+  )
 }
 ```
 
@@ -66,23 +67,25 @@ This can improve user experience since it can serve as a mechanism for lazy load
 #### Usage
 
 ```javascript
-import { Image, View } from 'react-native';
-import { Viewport } from '@skele/components';
+import { Image, View } from 'react-native'
+import { Viewport } from '@skele/components'
 
 const Placeholder = () =>
   <View style={{ width: 50, height: 50, backgroundColor: 'darkgrey' }} />
 
-const ViewportAwareImageWithPlaceholder =
-  Viewport.Aware(Viewport.WithPlaceholder(Image, Placeholder));
+const VAImgWithPlaceholder =
+  Viewport.Aware(
+    Viewport.WithPlaceholder(Image, Placeholder)
+  )
 
 render() {
   return (
-    <ViewportAwareImageWithPlaceholder
+    <VAImgWithPlaceholder
       // placeholder={Placeholder} // passing down a placeholder at render time
       source={{ uri: 'https://facebook.github.io/react-native/img/header_logo.png' }}
       preTriggerRatio={0.5}
       style={{ width: 50, height: 50 }} />
-  );
+  )
 }
 ```
 

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -2,13 +2,13 @@
 
 import ViewportTracker from './viewport/tracker'
 import ViewportAware from './viewport/aware'
-import WithPlaceHolder from './viewport/withPlaceHolder'
+import WithPlaceholder from './viewport/withPlaceholder'
 import WithEvents from './shared/WithEvents'
 
 const Viewport = {
   Tracker: ViewportTracker,
   Aware: ViewportAware,
-  WithPlaceHolder: WithPlaceHolder,
+  WithPlaceholder: WithPlaceholder,
 }
 
 const Mixins = {

--- a/packages/components/src/viewport/withPlaceHolder/index.web.js
+++ b/packages/components/src/viewport/withPlaceHolder/index.web.js
@@ -1,5 +1,0 @@
-'use strict'
-
-export default () => {
-  throw new Error('WithPlaceHolder: Not implemented!')
-}

--- a/packages/components/src/viewport/withPlaceholder/index.js
+++ b/packages/components/src/viewport/withPlaceholder/index.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default (WrappedComponent, PlaceHolderComponent) => {
+export default (WrappedComponent, PlaceholderComponent) => {
   return class extends React.Component {
     constructor(props, context) {
       super(props, context)
@@ -13,19 +13,19 @@ export default (WrappedComponent, PlaceHolderComponent) => {
       if (this.props.inViewport) {
         return <WrappedComponent {...this.props} />
       }
-      return this.props.placeHolder ? (
-        <this.props.placeHolder />
-      ) : PlaceHolderComponent ? (
-        <PlaceHolderComponent />
+      return this.props.placeholder ? (
+        <this.props.placeholder />
+      ) : PlaceholderComponent ? (
+        <PlaceholderComponent />
       ) : null
     }
 
     static propTypes = {
       inViewport: PropTypes.bool.isRequired,
-      placeHolder: PropTypes.func,
+      placeholder: PropTypes.func,
     }
 
-    static displayName = `WithPlaceHolder(${WrappedComponent.displayName ||
+    static displayName = `WithPlaceholder(${WrappedComponent.displayName ||
       WrappedComponent.name ||
       'Component'})`
   }

--- a/packages/components/src/viewport/withPlaceholder/index.web.js
+++ b/packages/components/src/viewport/withPlaceholder/index.web.js
@@ -1,0 +1,5 @@
+'use strict'
+
+export default () => {
+  throw new Error('WithPlaceholder: Not implemented!')
+}


### PR DESCRIPTION
- Added `onViewportEnter` and `onViewportLeave` callbacks to `Viewport.Aware`
- Used the chance to refactor `WithPlaceHolder` to `WithPlaceholder`, since "placeholder" is a single word
- Extended the Skele Components documentation