### PR TITLE
feat(core): memoize the normalize function

### DIFF
--- a/packages/core/src/data/__tests__/element-benchmarks.js
+++ b/packages/core/src/data/__tests__/element-benchmarks.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+
+import { Suite } from 'benchmark'
+import I from 'immutable'
+
+import { canonical, isOfKind } from '../'
+
+describe('element benchmarks', () => {
+  const detective = I.fromJS({
+    kind: ['detective', 'the', 'smartest'],
+    name: 'Sherlock Holmes',
+  })
+
+  test.skip('canonical', () => {
+    new Suite()
+      .add('canonical memoized', () => {
+        for (let i = 0; i < 10; i++) {
+          canonical('detective')
+          canonical(['detective', 'the'])
+          canonical(['detective', 'the', 'smartest'])
+          canonical(['detective', 'the', 'smartest', 'ever'])
+        }
+      })
+      .on('cycle', function(event) {
+        console.log(event.target.toString())
+      })
+      .run()
+  })
+
+  test.skip('isOfKind', () => {
+    new Suite()
+      .add('isOfKind memoized', () => {
+        for (let i = 0; i < 10; i++) {
+          isOfKind('detective', detective)
+          isOfKind(['detective', 'the'], detective)
+          isOfKind(['detective', 'the', 'smartest'], detective)
+          isOfKind(['detective', 'the', 'smartest', 'ever'], detective)
+        }
+      })
+      .on('cycle', function(event) {
+        console.log(event.target.toString())
+      })
+      .run()
+  })
+})

--- a/packages/core/src/data/__tests__/element-benchmarks.js
+++ b/packages/core/src/data/__tests__/element-benchmarks.js
@@ -16,12 +16,10 @@ describe('element benchmarks', () => {
   test.skip('canonical', () => {
     new Suite()
       .add('canonical memoized', () => {
-        for (let i = 0; i < 10; i++) {
-          canonical('detective')
-          canonical(['detective', 'the'])
-          canonical(['detective', 'the', 'smartest'])
-          canonical(['detective', 'the', 'smartest', 'ever'])
-        }
+        canonical('detective')
+        canonical(['detective', 'the'])
+        canonical(['detective', 'the', 'smartest'])
+        canonical(['detective', 'the', 'smartest', 'ever'])
       })
       .on('cycle', function(event) {
         console.log(event.target.toString())
@@ -32,12 +30,10 @@ describe('element benchmarks', () => {
   test.skip('isOfKind', () => {
     new Suite()
       .add('isOfKind memoized', () => {
-        for (let i = 0; i < 10; i++) {
-          isOfKind('detective', detective)
-          isOfKind(['detective', 'the'], detective)
-          isOfKind(['detective', 'the', 'smartest'], detective)
-          isOfKind(['detective', 'the', 'smartest', 'ever'], detective)
-        }
+        isOfKind('detective', detective)
+        isOfKind(['detective', 'the'], detective)
+        isOfKind(['detective', 'the', 'smartest'], detective)
+        isOfKind(['detective', 'the', 'smartest', 'ever'], detective)
       })
       .on('cycle', function(event) {
         console.log(event.target.toString())

--- a/packages/core/src/data/__tests__/element-benchmarks.js
+++ b/packages/core/src/data/__tests__/element-benchmarks.js
@@ -5,11 +5,23 @@
 import { Suite } from 'benchmark'
 import I from 'immutable'
 
-import { canonical, isOfKind } from '../'
+import { canonical, isOfKind, kindOf } from '../'
 
 describe('element benchmarks', () => {
-  const detective = I.fromJS({
+  const detective1 = I.fromJS({
+    kind: 'detective',
+    name: 'Sherlock Holmes',
+  })
+  const detective2 = I.fromJS({
+    kind: ['detective', 'the'],
+    name: 'Sherlock Holmes',
+  })
+  const detective3 = I.fromJS({
     kind: ['detective', 'the', 'smartest'],
+    name: 'Sherlock Holmes',
+  })
+  const detective4 = I.fromJS({
+    kind: ['detective', 'the', 'smartest', 'ever'],
     name: 'Sherlock Holmes',
   })
 
@@ -30,10 +42,24 @@ describe('element benchmarks', () => {
   test.skip('isOfKind', () => {
     new Suite()
       .add('isOfKind memoized', () => {
-        isOfKind('detective', detective)
-        isOfKind(['detective', 'the'], detective)
-        isOfKind(['detective', 'the', 'smartest'], detective)
-        isOfKind(['detective', 'the', 'smartest', 'ever'], detective)
+        isOfKind('detective', detective3)
+        isOfKind(['detective', 'the'], detective3)
+        isOfKind(['detective', 'the', 'smartest'], detective3)
+        isOfKind(['detective', 'the', 'smartest', 'ever'], detective3)
+      })
+      .on('cycle', function(event) {
+        console.log(event.target.toString())
+      })
+      .run()
+  })
+
+  test.skip('kindOf', () => {
+    new Suite()
+      .add('kindOf memoized', () => {
+        kindOf(detective1)
+        kindOf(detective2)
+        kindOf(detective3)
+        kindOf(detective4)
       })
       .on('cycle', function(event) {
         console.log(event.target.toString())

--- a/packages/core/src/data/__tests__/element.js
+++ b/packages/core/src/data/__tests__/element.js
@@ -142,8 +142,8 @@ describe('element', function() {
   })
 
   it('properly normalizes element kinds', function() {
-    expect(canonical(null)).toEqual(null)
-    expect(canonical(true)).toEqual(null)
+    expect(canonical(null) == null).toBe(true)
+    expect(canonical(true) == null).toBe(true)
     expect(canonical('component')).toEqual(List.of('component'))
     expect(canonical(['component', 'test'])).toEqual(
       List.of('component', 'test')

--- a/packages/core/src/data/element.js
+++ b/packages/core/src/data/element.js
@@ -115,14 +115,6 @@ export function ancestorKinds(ref) {
   return Seq(subKinds())
 }
 
-/**
- * @param ref an element reference
- * @returns the canonical version for the reference kind
- */
-export function canonical(ref) {
-  return normalize(ref)
-}
-
 function _normalize(kind) {
   if (typeof kind === 'string') {
     return List.of(kind)
@@ -144,6 +136,11 @@ function _normalize(kind) {
 }
 
 const normalize = memoize(_normalize)
+
+/**
+ * @returns the canonical version for the reference kind
+ */
+export const canonical = normalize
 
 export function pathsToChildElements(element) {
   return childPositions(element).flatMap(childrenPath => {

--- a/packages/core/src/data/element.js
+++ b/packages/core/src/data/element.js
@@ -2,8 +2,9 @@
 
 import * as R from 'ramda'
 import invariant from 'invariant'
-import deprecated from '../log/deprecated'
 import { List, Seq, is, Iterable } from 'immutable'
+import memoize from '../registry/memoize'
+import deprecated from '../log/deprecated'
 
 /**
  * Checks if a given object is of the provided kind.
@@ -48,7 +49,7 @@ export function isElementRef(obj) {
  * @returns {*}
  */
 export const isExactlyOfKind = R.curry(function isExactlyOfKind(kind, element) {
-  if (element == null || kindOf(element) == null) {
+  if (element == null) {
     return false
   }
 
@@ -122,9 +123,9 @@ export function canonical(ref) {
   return normalize(ref)
 }
 
-function normalize(kind) {
+function _normalize(kind) {
   if (typeof kind === 'string') {
-    return normalize([kind])
+    return List.of(kind)
   }
 
   if (Array.isArray(kind)) {
@@ -141,6 +142,8 @@ function normalize(kind) {
 
   return null
 }
+
+const normalize = memoize(_normalize)
 
 export function pathsToChildElements(element) {
   return childPositions(element).flatMap(childrenPath => {

--- a/packages/core/src/registry/Registry.js
+++ b/packages/core/src/registry/Registry.js
@@ -4,8 +4,14 @@ import { List } from 'immutable'
 import Trie from './impl/Trie'
 
 export function adaptKey(key) {
+  // prettier-ignore
   if (key instanceof List) {
-    // cast
+    if (key.size === 0) return []
+    if (key.size === 1) return [key.get(0)]
+    if (key.size === 2) return [key.get(0), key.get(1)]
+    if (key.size === 3) return [key.get(0), key.get(1), key.get(2)]
+    if (key.size === 4) return [key.get(0), key.get(1), key.get(2), key.get(3)]
+    if (key.size === 5) return [key.get(0), key.get(1), key.get(2), key.get(3), key.get(4)]
     return key.toArray()
   }
   return key

--- a/packages/core/src/registry/__tests__/Registry.js
+++ b/packages/core/src/registry/__tests__/Registry.js
@@ -2,7 +2,23 @@
 
 import { List } from 'immutable'
 
-import Registry from '../Registry'
+import Registry, { adaptKey } from '../Registry'
+
+describe('adaptKey', () => {
+  it('properly adapts keys', () => {
+    expect(adaptKey(null)).toEqual(null)
+    expect(adaptKey([])).toEqual([])
+    expect(adaptKey(List([]))).toEqual([])
+    expect(adaptKey(List.of('one', 'two', 'three'))).toEqual([
+      'one',
+      'two',
+      'three',
+    ])
+    expect(
+      adaptKey(List.of('one', 'two', 'three', 'four', 'five', 'six', 'seven'))
+    ).toEqual(['one', 'two', 'three', 'four', 'five', 'six', 'seven'])
+  })
+})
 
 describe('Registry', () => {
   const registry = new Registry()


### PR DESCRIPTION
Resolves #120.

Initial benchmarks:
```
canonical non-memoized x 116,203 ops/sec ±8.39% (69 runs sampled)
isOfKind non-memoized x 61,168 ops/sec ±0.26% (95 runs sampled)

canonical memoized x 512,298 ops/sec ±8.66% (71 runs sampled)
isOfKind memoized x 69,476 ops/sec ±0.56% (86 runs sampled)
```

Check https://github.com/netceteragroup/skele/pull/124#issuecomment-445448152 for updated benchmarks.