### PR TITLE
Make editCond to work with all kinds (specific or abstract)

### DIFF
--- a/packages/core/src/zip/__tests__/edit.js
+++ b/packages/core/src/zip/__tests__/edit.js
@@ -28,7 +28,7 @@ describe('Editing a Zipper', () => {
         name: 'andon',
         children: [
           {
-            kind: 'tm',
+            kind: ['tm', 'yoga'],
             name: 'blagoja',
           },
           {
@@ -60,6 +60,7 @@ describe('Editing a Zipper', () => {
           item => item.get('name') === 'andon',
           item => item.set('name', 'sikavica'),
         ],
+        [['tm', 'yoga'], item => item.update('name', name => `yoga-${name}`)],
         ['tm', item => item.update('name', name => `member-${name}`)],
       ],
       elementZipper
@@ -90,8 +91,8 @@ describe('Editing a Zipper', () => {
             name: 'sikavica', // changed
             children: [
               {
-                kind: 'tm',
-                name: 'member-blagoja', // changed
+                kind: ['tm', 'yoga'],
+                name: 'yoga-member-blagoja', // changed
               },
               {
                 kind: 'tm',

--- a/packages/core/src/zip/edit.js
+++ b/packages/core/src/zip/edit.js
@@ -5,10 +5,10 @@ import { postWalk } from '../zip'
 import * as zip from './impl'
 import { curry } from 'ramda'
 
-import Registry from '../registry/Registry'
+import MultivalueRegistry from '../registry/MultivalueRegistry'
 
 export const editCond = (patterns, loc) => {
-  const kinds = new Registry()
+  const kinds = new MultivalueRegistry()
   const preds = []
 
   patterns.forEach(([pred, f]) => {
@@ -22,9 +22,7 @@ export const editCond = (patterns, loc) => {
   const editFn = l =>
     postWalk(el => {
       const kind = kindOf(el)
-      const f = kind != null && kinds.get(kind)
-
-      if (f != null) el = f(el)
+      el = kinds.get(kind).reduce((el, f) => f(el), el)
 
       const after = preds.reduce((el, [pred, f]) => (pred(el) ? f(el) : el), el)
       return after


### PR DESCRIPTION
There is a bug in the implementation of editCond. Performance optimization introduced, have made usage of "patterns" for kinds to be stored in a Registry, making the usage to only return one transformation per kind.

By moving to MultivalueRegistry, we again are doing all registered transformations.