### PR TITLE
refactor(classic): Dispatch global actions with undefined cursor to occur on a viable parent level

### DIFF
--- a/packages/classic/src/kernel.js
+++ b/packages/classic/src/kernel.js
@@ -106,7 +106,25 @@ class Kernel {
 
     return {
       dispatch(action) {
-        self.dispatch(actions.atCursor(self.query(path), action))
+        const element = self.query(path)
+        if (element) {
+          self.dispatch(actions.atCursor(element, action))
+        } else if (
+          element === undefined &&
+          action.type &&
+          action.type.startsWith('.')
+        ) {
+          while (path.length) {
+            const parentPath = path.slice(0, -1)
+            const parentElement = self.query(parentPath)
+            const isIndexed = I.Iterable.isIndexed(parentElement)
+            if (parentElement && !isIndexed) {
+              self.dispatch(actions.atCursor(parentElement, action))
+              break
+            }
+            path.pop()
+          }
+        }
       },
 
       query(subPath) {


### PR DESCRIPTION
We briefly discussed this with @ognen.

We only want to do this for global actions that are being dispatched. There are some cases where the result of `.query(path)` returns `undefined` due to no cursor being present at that path anymore. This causes the dispatch to fizzle out because `actions.atCursor` will fail at [this line](https://github.com/netceteragroup/skele/blob/master/packages/classic/src/action.js#L18), when trying to access `_keyPath` from `undefined`.

Anyway, I opened this PR in order to discuss this first and see if we can tackle this problem another way.
